### PR TITLE
Added Admin Check for Hanger Wipe.

### DIFF
--- a/Utilities/HangarChecks.cs
+++ b/Utilities/HangarChecks.cs
@@ -347,7 +347,12 @@ namespace QuantumHangar.Utilities
                 chat.Respond("You have no grids in your hangar!");
                 return;
             }
-
+            
+            if(!Plugin.Config.requireAdminPermForHangarWipe)
+            {
+                chat.Respond("You don't have permission to wipe your entire Hanger!");
+                return;
+            }
 
 
             int result = -1;

--- a/Utilities/Settings.cs
+++ b/Utilities/Settings.cs
@@ -170,10 +170,8 @@ namespace QuantumHangar
         public bool OnLoadTransfer { get => _OnLoadTransfer; set => SetValue(ref _OnLoadTransfer, value); }
 
         //ExtendedConfigs
-        private bool _requireAdminPermForHangarWipe = true;
+        private bool _requireAdminPermForHangarWipe = false;
         public bool requireAdminPermForHangarWipe { get => _requireAdminPermForHangarWipe;}
-
-
 
 
         //Single slot

--- a/Utilities/Settings.cs
+++ b/Utilities/Settings.cs
@@ -170,6 +170,8 @@ namespace QuantumHangar
         public bool OnLoadTransfer { get => _OnLoadTransfer; set => SetValue(ref _OnLoadTransfer, value); }
 
         //ExtendedConfigs
+        private bool _requireAdminPermForHangarWipe = true;
+        public bool requireAdminPermForHangarWipe { get => _requireAdminPermForHangarWipe;}
 
 
 


### PR DESCRIPTION
Created a new Bool in the Settings.cs
_requireAdminPermForHangarWipe 
By default is False. 
if True.
This prevents a player from accidentally wiping their entire hangar.
if False.
They can wipe their hangar with !hangar Remove 0 as originally written. 