### PR TITLE
Add chat command toggle for hangar save

### DIFF
--- a/ChatCommands.cs
+++ b/ChatCommands.cs
@@ -65,6 +65,20 @@ namespace QuantumHangar
 
         private Hangar Plugin => (Hangar)Context.Plugin;
 
+        [Command("disable", "Disables hangar save function until re enabled")]
+        [Permission(MyPromoteLevel.Moderator)]
+        public void disable()
+        {
+            Hangar.IsDisabled = true;
+        }
+        [Command("enable", "enables hangar save function ")]
+        [Permission(MyPromoteLevel.Moderator)]
+        public void enable()
+        {
+            Hangar.IsDisabled = false;
+        }
+
+
         [Command("save", "Saves targeted grid in hangar")]
         [Permission(MyPromoteLevel.None)]
         public void Save()

--- a/Hangar.cs
+++ b/Hangar.cs
@@ -48,7 +48,7 @@ namespace QuantumHangar
 
         private static bool EnableDebug = true;
         public static bool IsRunning = false;
-
+        public static bool IsEnabled = true;
 
         private bool ServerRunning;
         public static MethodInfo CheckFuture;

--- a/Utilities/HangarChecks.cs
+++ b/Utilities/HangarChecks.cs
@@ -139,6 +139,12 @@ namespace QuantumHangar.Utilities
                 || !CheckHanagarLimits(Data))
                 return;
 
+            //Check Player Timer
+            if (!CheckPlayerTimeStamp(ref Data))
+            {
+                chat.Respond("Hangar is disabled by server");
+                return;
+            }
 
 
 


### PR DESCRIPTION
We have had a number of issues where players save a grid after our force save during a 4 hour restart schedule which duplicates one grid on the server and one grid in the hangar

the simple solution though probably not the most elegant is to have a command just before the save command to lock the hangar save function, I have also made the command available to moderators or above, and if used paired it with an enable function.


Im unable to compile the code as i keep getting errors from your part of the repository with VRageMath.Color that im not skilled enough in visual studio to resolve